### PR TITLE
fix(proptype): allow array as value for Slider > Control and others...

### DIFF
--- a/components/Slider/Control.js
+++ b/components/Slider/Control.js
@@ -151,5 +151,8 @@ Control.propTypes = {
   step: PropTypes.number.isRequired,
   toolTipTemplate: PropTypes.func.isRequired,
   trackOffset: PropTypes.object.isRequired,
-  value: PropTypes.number.isRequired
+  value: PropTypes.oneOfType([
+    React.PropTypes.number,
+    React.PropTypes.array
+  ]).isRequired,
 };

--- a/components/Slider/Rail.js
+++ b/components/Slider/Rail.js
@@ -50,5 +50,8 @@ Rail.propTypes = {
   max: PropTypes.number.isRequired,
   min: PropTypes.number.isRequired,
   orientation: PropTypes.string.isRequired,
-  value: PropTypes.array.isRequired
+  value: PropTypes.oneOfType([
+    React.PropTypes.number,
+    React.PropTypes.array
+  ]).isRequired,
 };

--- a/stories/Container.js
+++ b/stories/Container.js
@@ -36,9 +36,11 @@ export default class Container extends Component {
 
 Container.propTypes = {
   action: PropTypes.func,
-  value: PropTypes.oneOfType(
-    [PropTypes.array, PropTypes.bool]
-  ),
+  value: PropTypes.oneOfType([
+    PropTypes.number,
+    PropTypes.array,
+    PropTypes.bool,
+  ]),
   children: PropTypes.element,
   className: PropTypes.string
 };


### PR DESCRIPTION
allow array as value for Slider > Control
allow number as value for Slider > Rail
allow number as value for Stories > Container

Fixed WARNING
Warning: Failed prop type: Invalid prop `value` of type `array` supplied to `Control`, expected `number`.
Warning: Failed prop type: Invalid prop `value` of type `number` supplied to `Rail`, expected `array`.
Warning: Failed prop type: Invalid prop `value` supplied to `Container`.
    in Container